### PR TITLE
[Meta Schedule] Update Tune Relay

### DIFF
--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -177,7 +177,7 @@ class ApplyHistoryBest(MetaScheduleContext):
     pass
 
 
-def extract_task(
+def extract_task_from_relay(
     mod: Union[IRModule, RelayFunc],
     target: Target,
     params: Optional[Dict[str, NDArray]] = None,

--- a/python/tvm/meta_schedule/integration.py
+++ b/python/tvm/meta_schedule/integration.py
@@ -20,6 +20,7 @@ from typing import Callable, Dict, List, Optional, Union
 
 from tvm._ffi import register_object
 from tvm.ir import IRModule, transform
+from tvm.meta_schedule.database.database import Database
 from tvm.relay import Any, Function as RelayFunc, vm
 from tvm.runtime import NDArray, Object
 from tvm.target import Target
@@ -174,7 +175,13 @@ class TaskExtraction(MetaScheduleContext):
 
 @register_object("meta_schedule.ApplyHistoryBest")
 class ApplyHistoryBest(MetaScheduleContext):
-    pass
+    """An integration context that allows application of historically best records from a database"""
+
+    database: Database
+    """ The database to be queried from"""
+
+    def __init__(self, database) -> None:
+        self.__init_handle_by_constructor__(_ffi_api.ApplyHistoryBest, database)  # type: ignore # pylint: disable=no-member
 
 
 def extract_task_from_relay(

--- a/src/tir/schedule/primitive.h
+++ b/src/tir/schedule/primitive.h
@@ -28,15 +28,6 @@
 namespace tvm {
 namespace tir {
 
-/*!
- * \brief Create a sampling function that does multinomial sampling.
- * \param rand_state The random state.
- * \param weights The weights for multinomial sampling.
- * \return The multinomial sampling function.
- */
-TVM_DLL std::function<int32_t()> MakeMultinomialSampler(
-    support::LinearCongruentialEngine::TRandState* rand_state, const std::vector<double>& weights);
-
 /******** Schedule: Sampling ********/
 /*!
  * \brief Sample a random integer from a given range.

--- a/tests/python/unittest/test_meta_schedule_integration.py
+++ b/tests/python/unittest/test_meta_schedule_integration.py
@@ -112,7 +112,7 @@ def test_meta_schedule_integration_extract_from_resnet():
         layout="NHWC",
         dtype="float32",
     )
-    extracted_tasks = ms.integration.extract_task(mod, target="llvm", params=params)
+    extracted_tasks = ms.integration.extract_task_from_relay(mod, target="llvm", params=params)
     assert len(extracted_tasks) == 30
 
 

--- a/tests/python/unittest/test_meta_schedule_task_extraction.py
+++ b/tests/python/unittest/test_meta_schedule_task_extraction.py
@@ -91,7 +91,7 @@ def test_meta_schedule_extract_from_torch_model(model_name: str, batch_size: int
         dtype="float32",
     )
     target = tvm.target.Target(target)
-    ms.integration.extract_task(mod, params=params, target=target)
+    ms.integration.extract_task_from_relay(mod, params=params, target=target)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Migrated from tlc-pack repo [#558](https://github.com/tlc-pack/tvm-tensorir/pull/558).

Multiple updates on `tune_relay`, updated task name, changed `extract_task` to `extract_task_from_relay`, added duplication and cherry-picked Siyuan's fix on Layout free place holder script printing. Also added: `ApplyHistoryBest`.