### PR TITLE
[BugFix] Apply bound predicate directly to loops when possible

### DIFF
--- a/include/tvm/tir/transform.h
+++ b/include/tvm/tir/transform.h
@@ -383,6 +383,13 @@ TVM_DLL Pass LowerInitBlock();
  */
 TVM_DLL Pass PlanAndUpdateBufferAllocationLocation();
 
+/*! // Todo
+ * \brief
+ *
+ * \return TVM_DLL
+ */
+TVM_DLL Pass ApplyBlockBoundPredicate();
+
 /*!
  * \brief Substitute all the block vars with the PrimExprs they are bound to, indicated by the
  *        corresponding iter_values in BlockRealize, for opaque blocks by removing all

--- a/include/tvm/tir/transform.h
+++ b/include/tvm/tir/transform.h
@@ -383,10 +383,10 @@ TVM_DLL Pass LowerInitBlock();
  */
 TVM_DLL Pass PlanAndUpdateBufferAllocationLocation();
 
-/*! // Todo
- * \brief
- *
- * \return TVM_DLL
+/*!
+ * \brief Narrow the extents of some loops by checking whether some constraints in the block iter
+ * bound predicates can be directly applied on the loops.
+ * \return The pass.
  */
 TVM_DLL Pass ApplyBlockBoundPredicate();
 

--- a/python/tvm/tir/transform/transform.py
+++ b/python/tvm/tir/transform/transform.py
@@ -624,6 +624,11 @@ def PlanAndUpdateBufferAllocationLocation():
     return _ffi_api.PlanAndUpdateBufferAllocationLocation()  # type: ignore
 
 
+def ApplyBlockBoundPredicate():
+    """# Todo"""
+    return _ffi_api.ApplyBlockBoundPredicate()  # type: ignore
+
+
 def ConvertBlocksToOpaque():
     """Substitute all the block vars with the PrimExprs they are bound to, indicated by
     the corresponding iter_values in BlockRealize, and then convert the blocks into

--- a/python/tvm/tir/transform/transform.py
+++ b/python/tvm/tir/transform/transform.py
@@ -625,7 +625,14 @@ def PlanAndUpdateBufferAllocationLocation():
 
 
 def ApplyBlockBoundPredicate():
-    """# Todo"""
+    """Narrow the extents of some loops by checking whether some constraints in the block iter
+    bound predicates can be directly applied on the loops.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
     return _ffi_api.ApplyBlockBoundPredicate()  # type: ignore
 
 

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <mutex>
 #include <stack>
+#include <tvm/ir/transform.h>
 
 #include "../printer/text_printer.h"
 

--- a/src/driver/driver_api.cc
+++ b/src/driver/driver_api.cc
@@ -37,7 +37,6 @@
 #include <stack>
 
 #include "../printer/text_printer.h"
-#include <tvm/ir/transform.h>
 
 namespace tvm {
 
@@ -251,6 +250,7 @@ Array<tvm::transform::Pass> CreatePassList(bool disable_loop_partition) {
   pass_list.push_back(tir::transform::LowerCrossThreadReduction());
   pass_list.push_back(tir::transform::LowerInitBlock());
   pass_list.push_back(tir::transform::PlanAndUpdateBufferAllocationLocation());
+  pass_list.push_back(tir::transform::ApplyBlockBoundPredicate());
   pass_list.push_back(tir::transform::ConvertBlocksToOpaque());
   pass_list.push_back(tir::transform::CompactBufferAllocation());
   pass_list.push_back(tir::transform::Simplify());

--- a/src/meta_schedule/feature_extractor/per_store_feature.cc
+++ b/src/meta_schedule/feature_extractor/per_store_feature.cc
@@ -287,6 +287,7 @@ Sequential PassListForPerStoreFeature() {
       tir::transform::LowerCrossThreadReduction(),
       tir::transform::LowerInitBlock(),
       tir::transform::PlanAndUpdateBufferAllocationLocation(),
+      tir::transform::ApplyBlockBoundPredicate(),
       tir::transform::ConvertBlocksToOpaque(),
       tir::transform::UnifyThreadBinding(),
       tir::transform::CompactBufferAllocation(),

--- a/src/meta_schedule/postproc/verify_gpu_code.cc
+++ b/src/meta_schedule/postproc/verify_gpu_code.cc
@@ -77,6 +77,7 @@ class VerifyGPUCodeNode : public PostprocNode {
           pass_list.push_back(tir::transform::LowerCrossThreadReduction());
           pass_list.push_back(tir::transform::LowerInitBlock());
           pass_list.push_back(tir::transform::PlanAndUpdateBufferAllocationLocation());
+          pass_list.push_back(tir::transform::ApplyBlockBoundPredicate());
           pass_list.push_back(tir::transform::ConvertBlocksToOpaque());
           pass_list.push_back(tir::transform::CompactBufferAllocation());
           pass_list.push_back(tir::transform::Simplify());

--- a/src/tir/schedule/primitive/compute_at.cc
+++ b/src/tir/schedule/primitive/compute_at.cc
@@ -249,11 +249,11 @@ class ScopeReconstructor : private StmtMutator {
           analyzer->Bind(var, Range::FromMinExtent(0, iter_dom->extent));
         }
         if (pred_bound.HasLowerBound()) {
-          PrimExpr lower_bound = iter_dom->min + var >= pred_bound.min();
+          PrimExpr lower_bound = block_->iter_vars[i]->var >= pred_bound.min();
           predicate = predicate && lower_bound;
         }
         if (pred_bound.HasUpperBound()) {
-          PrimExpr upper_bound = iter_dom->min + var < pred_bound.max() + 1;
+          PrimExpr upper_bound = block_->iter_vars[i]->var < pred_bound.max() + 1;
           predicate = predicate && upper_bound;
         }
       } else {

--- a/src/tir/transforms/apply_block_bound_predicate.cc
+++ b/src/tir/transforms/apply_block_bound_predicate.cc
@@ -97,8 +97,8 @@ class BoundPredicateParserSimplifier : public ExprMutator {
 };
 
 /*!
- * \brief Substitute expr via BlockRealize value bindings and convert each block into opaque
- *        blocks. // Todo
+ * \brief Narrow the extents of some loops by checking whether some constraints in the block iter
+ * bound predicates can be directly applied on the loops.
  */
 class LoopExtentMutator : public StmtMutator {
  private:
@@ -155,8 +155,9 @@ class LoopExtentMutator : public StmtMutator {
     return For(p_new_loop);
   }
 
-  /*! \brief */  // Todo
+  /*! \brief The bounds of loop vars, provided by the block iter bound predicate */
   Map<Var, arith::IntSet> bound_intset_;
+  /*! \brief The analyzer */
   arith::Analyzer ana_;
 };
 

--- a/src/tir/transforms/apply_block_bound_predicate.cc
+++ b/src/tir/transforms/apply_block_bound_predicate.cc
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file apply_block_bound_predicate.cc
+ * \brief Apply the block iter bound predicate to loops.
+ */
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include "../../arith/pattern_match.h"
+#include "ir_utils.h"
+
+namespace tvm {
+namespace tir {
+
+class BoundPredicateParserSimplifier : public ExprMutator {
+ public:
+  explicit BoundPredicateParserSimplifier(Map<Var, PrimExpr> binding_map,
+                                          Map<Var, arith::IntSet>* bound_intset)
+      : binding_map_(std::move(binding_map)), bound_intset_(bound_intset) {}
+
+ private:
+  PrimExpr VisitExpr(const PrimExpr& expr) final {
+    if (expr->IsInstance<AndNode>() || expr->IsInstance<LTNode>() || expr->IsInstance<GENode>()) {
+      return ExprMutator::VisitExpr(expr);
+    }
+    ICHECK(false) << "InternalError: PrimExpr \"" << expr
+                  << "\" is not supposed to appear as a bound predicate";
+    throw;
+  }
+
+  PrimExpr VisitExpr_(const LTNode* lt) final {
+    const VarNode* var = lt->a.as<VarNode>();
+    if (!var) {
+      ICHECK(false) << "InternalError: LHS of logical expression here is required to be variables";
+    }
+    Optional<PrimExpr> binding = binding_map_.Get(GetRef<Var>(var));
+    if (!binding.defined()) {
+      ICHECK(false) << "InternalError: The LHS variable is supposed to be a block iterator";
+    }
+    const VarNode* loop_var = binding.value().as<VarNode>();
+    if (!loop_var) {
+      return GetRef<PrimExpr>(lt);
+    }
+
+    arith::IntSet intset =
+        bound_intset_->Get(GetRef<Var>(loop_var)).value_or(arith::IntSet::Everything());
+    intset = arith::Intersect(
+        {intset, arith::IntSet::FromRange(Range(min_value(lt->b.dtype()), lt->b))});
+    bound_intset_->Set(GetRef<Var>(loop_var), intset);
+    return const_true();
+  }
+
+  PrimExpr VisitExpr_(const GENode* ge) final {
+    const VarNode* var = ge->a.as<VarNode>();
+    if (!var) {
+      ICHECK(false) << "InternalError: LHS of logical expression here is required to be variables";
+    }
+    Optional<PrimExpr> binding = binding_map_.Get(GetRef<Var>(var));
+    if (!binding.defined()) {
+      ICHECK(false) << "InternalError: The LHS variable is supposed to be a block iterator";
+    }
+    const VarNode* loop_var = binding.value().as<VarNode>();
+    if (!loop_var) {
+      return GetRef<PrimExpr>(ge);
+    }
+
+    arith::IntSet intset =
+        bound_intset_->Get(GetRef<Var>(loop_var)).value_or(arith::IntSet::Everything());
+    intset = arith::Intersect(
+        {intset, arith::IntSet::FromRange(Range(ge->b, max_value(ge->b.dtype())))});
+    bound_intset_->Set(GetRef<Var>(loop_var), intset);
+    return const_true();
+  }
+
+  Map<Var, PrimExpr> binding_map_;
+  Map<Var, arith::IntSet>* bound_intset_;
+};
+
+/*!
+ * \brief Substitute expr via BlockRealize value bindings and convert each block into opaque
+ *        blocks. // Todo
+ */
+class LoopExtentMutator : public StmtMutator {
+ private:
+  Stmt VisitStmt_(const BlockRealizeNode* realize) final {
+    // Step 1. Mutate recursively.
+    BlockRealize new_realize = Downcast<BlockRealize>(StmtMutator::VisitStmt_(realize));
+    // Step 2. If the block has no "require_block_var_bound_predicate" annotation, skip this block.
+    Block block = new_realize->block;
+    const Optional<ObjectRef>& bound_predicate =
+        block->annotations.Get(tir::attr::require_block_var_bound_predicate);
+    if (!bound_predicate.defined()) {
+      return new_realize;
+    }
+    // Step 3. Make a mapping from block iters to bindings.
+    Map<Var, PrimExpr> binding_map;
+    ICHECK_EQ(block->iter_vars.size(), new_realize->iter_values.size());
+    int n_iter = static_cast<int>(block->iter_vars.size());
+    for (int i = 0; i < n_iter; ++i) {
+      binding_map.Set(block->iter_vars[i]->var, new_realize->iter_values[i]);
+    }
+    // Step 4. Parse the bound predicate, removing constraints on the block vars whose binding are
+    // single vars.
+    PrimExpr new_predicate = BoundPredicateParserSimplifier(
+        binding_map, &bound_intset_)(Downcast<PrimExpr>(bound_predicate.value()));
+    // Step 5. Update the block annotation and update the new block-realize.
+    ObjectPtr<BlockNode> p_new_block = CopyOnWrite(block.get());
+    if (ana_.CanProveEqual(new_predicate, const_true())) {
+      p_new_block->annotations.erase(tir::attr::require_block_var_bound_predicate);
+    } else {
+      p_new_block->annotations.Set(tir::attr::require_block_var_bound_predicate, new_predicate);
+    }
+    ObjectPtr<BlockRealizeNode> p_new_realize = CopyOnWrite(new_realize.get());
+    p_new_realize->block = Block(p_new_block);
+
+    return BlockRealize(p_new_realize);
+  }
+
+  Stmt VisitStmt_(const ForNode* loop) final {
+    // Step 1. Mutate recursively.
+    For new_loop = Downcast<For>(StmtMutator::VisitStmt_(loop));
+    // Step 2. Check whether this loop has a bound intset. If not, return the new loop.
+    Optional<arith::IntSet> intset = bound_intset_.Get(new_loop->loop_var);
+    if (!intset.defined()) {
+      return new_loop;
+    }
+    // Step 3. Update the new loop's `min` and `extent` according to the extent.
+    PrimExpr new_min = max(new_loop->min, intset.value().min());
+    PrimExpr new_extent = min(new_loop->min + new_loop->extent, intset.value().max() + 1) - new_min;
+    // Step 4. Update the new loop.
+    ObjectPtr<ForNode> p_new_loop = CopyOnWrite(new_loop.get());
+    p_new_loop->min = ana_.Simplify(new_min);
+    p_new_loop->extent = ana_.Simplify(new_extent);
+
+    return For(p_new_loop);
+  }
+
+  /*! \brief */  // Todo
+  Map<Var, arith::IntSet> bound_intset_;
+  arith::Analyzer ana_;
+};
+
+PrimFunc ApplyBlockBoundPredicate(PrimFunc f) {
+  // Only apply this pass to TIR that is not from TE schedules
+  if (!IsFromLegacyTESchedule(f)) {
+    PrimFuncNode* fptr = f.CopyOnWrite();
+    fptr->body = LoopExtentMutator()(f->body);
+    return f;
+  } else {
+    return f;
+  }
+}
+
+namespace transform {
+
+Pass ApplyBlockBoundPredicate() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    return ApplyBlockBoundPredicate(std::move(f));
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tir.ApplyBlockBoundPredicate", {});
+}
+
+TVM_REGISTER_GLOBAL("tir.transform.ApplyBlockBoundPredicate")
+    .set_body_typed(ApplyBlockBoundPredicate);
+}  // namespace transform
+
+}  // namespace tir
+}  // namespace tvm

--- a/tests/python/unittest/test_tir_schedule_compute_at.py
+++ b/tests/python/unittest/test_tir_schedule_compute_at.py
@@ -752,7 +752,7 @@ def read_out_of_bound_after_compute_at(A: T.Buffer[(16,), "float32"], C: T.Buffe
                 v = T.axis.spatial(16, j + ax0)
                 T.reads(A[v])
                 T.writes(B[v])
-                T.block_attr({"require_bound_predicate":j + ax0 >= 0 and j + ax0 < 16})
+                T.block_attr({"require_bound_predicate":v >= 0 and v < 16})
                 B[v] = A[v]
         with T.block("C"):
             v = T.axis.spatial(16, j)
@@ -809,7 +809,7 @@ def tiled_pooling_cache_after_compute_at(a: T.handle, b: T.handle) -> None:
                 w = T.axis.spatial(224, ww_0 * 8 - 1 + ax1)
                 T.reads(X[h, w])
                 T.writes(cache[h, w])
-                T.block_attr({"require_bound_predicate":hh_0 * 8 - 1 + ax0 >= 0 and hh_0 * 8 - 1 + ax0 < 224 and ww_0 * 8 - 1 + ax1 >= 0 and ww_0 * 8 - 1 + ax1 < 224})
+                T.block_attr({"require_bound_predicate":h >= 0 and h < 224 and w >= 0 and w < 224})
                 cache[h, w] = X[h, w]
         for ax0, ax1 in T.grid(10, 10):
             with T.block("dache"):
@@ -817,7 +817,7 @@ def tiled_pooling_cache_after_compute_at(a: T.handle, b: T.handle) -> None:
                 w = T.axis.spatial(224, ww_0 * 8 - 1 + ax1)
                 T.reads(X[h, w])
                 T.writes(dache[h, w])
-                T.block_attr({"require_bound_predicate":hh_0 * 8 - 1 + ax0 >= 0 and hh_0 * 8 - 1 + ax0 < 224 and ww_0 * 8 - 1 + ax1 >= 0 and ww_0 * 8 - 1 + ax1 < 224})
+                T.block_attr({"require_bound_predicate":h >= 0 and h < 224 and w >= 0 and w < 224})
                 dache[h, w] = X[h, w]
         for hh_1, ww_1, khh, kww in T.grid(8, 8, 3, 3):
             with T.block("compute"):

--- a/tests/python/unittest/test_tir_transform_apply_block_bound_predicate.py
+++ b/tests/python/unittest/test_tir_transform_apply_block_bound_predicate.py
@@ -1,0 +1,187 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import tvm
+from tvm import tir, te
+from tvm.script import tir as T
+
+
+def _check(original, transformed):
+    func = original
+    mod = tvm.IRModule.from_expr(func)
+    mod = tvm.tir.transform.ApplyBlockBoundPredicate()(mod)
+    mod = tvm.tir.transform.Simplify()(mod)
+    tvm.ir.assert_structural_equal(mod["main"], transformed, True)
+
+
+def _check_print(original):
+    func = original
+    mod = tvm.IRModule.from_expr(func)
+    mod = tvm.tir.transform.LowerCrossThreadReduction()(mod)
+    mod = tvm.tir.transform.LowerInitBlock()(mod)
+    mod = tvm.tir.transform.PlanAndUpdateBufferAllocationLocation()(mod)
+    mod = tvm.tir.transform.Simplify()(mod)
+    print(mod["main"].script())
+    mod = tvm.tir.transform.ApplyBlockBoundPredicate()(mod)
+    mod = tvm.tir.transform.Simplify()(mod)
+    print(mod["main"].script())
+
+
+# fmt: off
+# pylint: disable=no-member,invalid-name,unused-variable,line-too-long,redefined-outer-name,unexpected-keyword-arg,too-many-nested-blocks
+
+
+@T.prim_func
+def read_out_of_bound_after_compute_at(A: T.Buffer[(16,), "float32"], C: T.Buffer[(16,), "float32"]) -> None:
+    B = T.alloc_buffer([16], dtype="float32")
+    for j in T.serial(16):
+        for ax0 in T.serial(2):
+            with T.block("B"):
+                v = T.axis.spatial(16, j + ax0)
+                T.reads(A[v])
+                T.writes(B[v])
+                T.block_attr({"require_bound_predicate":v >= 0 and v < 16})
+                B[v] = A[v]
+        with T.block("C"):
+            v = T.axis.spatial(16, j)
+            T.reads(B[v : v + 2])
+            T.writes(C[v])
+            C[v] = T.if_then_else(v < 15, T.max(B[v], B[v + 1]), B[v], dtype="float32")
+
+
+@T.prim_func
+def tiled_pooling_cache_after_compute_at(a: T.handle, b: T.handle) -> None:
+    X = T.match_buffer(a, [224, 224], dtype="float32")
+    Y = T.match_buffer(b, [224, 224], dtype="float32")
+    cache = T.alloc_buffer([224, 224], dtype="float32")
+    dache = T.alloc_buffer([224, 224], dtype="float32")
+    for hh_0, ww_0 in T.grid(28, 28):
+        for ax0, ax1 in T.grid(10, 10):
+            with T.block("cache"):
+                h = T.axis.spatial(224, hh_0 * 8 + ax0 - 1)
+                w = T.axis.spatial(224, ww_0 * 8 + ax1 - 1)
+                T.reads(X[h, w])
+                T.writes(cache[h, w])
+                T.block_attr({"require_bound_predicate":h >= 0 and h < 224 and w >= 0 and w < 224})
+                cache[h, w] = X[h, w]
+        for ax0, ax1 in T.grid(10, 10):
+            with T.block("dache"):
+                h = T.axis.spatial(224, hh_0 * 8 + ax0 - 1)
+                w = T.axis.spatial(224, ww_0 * 8 + ax1 - 1)
+                T.reads(X[h, w])
+                T.writes(dache[h, w])
+                T.block_attr({"require_bound_predicate":h >= 0 and h < 224 and w >= 0 and w < 224})
+                dache[h, w] = X[h, w]
+        for hh_1, ww_1, khh, kww in T.grid(8, 8, 3, 3):
+            with T.block("compute"):
+                h = T.axis.spatial(224, hh_0 * 8 + hh_1)
+                w = T.axis.spatial(224, ww_0 * 8 + ww_1)
+                kh, kw = T.axis.remap("RR", [khh, kww])
+                T.reads([Y[h, w], cache[h + kh - 1, w + kw - 1], dache[h + kh - 1, w + kw - 1]])
+                T.writes([Y[h, w]])
+                with T.init():
+                    Y[h, w] = 0.0
+                Y[h, w] = T.max(Y[h, w], T.if_then_else(
+                    T.likely(1 <= h + kh, dtype="bool") and \
+                    T.likely(h + kh < 225, dtype="bool") and \
+                    T.likely(1 <= w + kw, dtype="bool") and \
+                    T.likely(w + kw < 225, dtype="bool"),
+                    cache[h + kh - 1, w + kw - 1]+ dache[h + kh - 1, w + kw - 1], 0.0, dtype="float32"))
+
+
+@T.prim_func
+def batch_norm_after_compute_at(A: T.Buffer[(1, 256, 256), "float32"], D: T.Buffer[(1,), "float32"]) -> None:
+    for i0_0 in T.serial(1):
+        with T.block():
+            T.reads(A[0 : 64, 0 : 256, 0 : 256])
+            T.writes(D[0 : 64])
+            C = T.alloc_buffer([1], dtype="float32")
+            for ax0, ax1, ax2 in T.grid(64, 256, 256):
+                with T.block("C"):
+                    b = T.axis.spatial(1, ax0)
+                    i, j = T.axis.remap("RR", [ax1, ax2])
+                    T.reads(C[b], A[b, i, j])
+                    T.writes(C[b])
+                    T.block_attr({"require_bound_predicate":b >= 0 and b < 1})
+                    if i == 0 and j == 0:
+                        C[b] = T.float32(0)
+                    C[b] = C[b] + A[b, i, j] * A[b, i, j]
+            for i0_1 in T.thread_binding(64, thread="threadIdx.x"):
+                with T.block("D"):
+                    b = T.axis.spatial(1, i0_1)
+                    T.where(i0_1 < 1)
+                    T.reads(C[b])
+                    T.writes(D[b])
+                    D[b] = T.sqrt(C[b], dtype="float32")
+
+
+@T.prim_func
+def transformed_batch_norm(A: T.Buffer[(1, 256, 256), "float32"], D: T.Buffer[(1,), "float32"]) -> None:
+    for i0_0 in T.serial(1):
+        with T.block():
+            T.reads(A[0 : 64, 0 : 256, 0 : 256])
+            T.writes(D[0 : 64])
+            C = T.alloc_buffer([1], dtype="float32")
+            for ax0, ax1, ax2 in T.grid(1, 256, 256):
+                with T.block("C"):
+                    b = T.axis.spatial(1, 0)
+                    i, j = T.axis.remap("RR", [ax1, ax2])
+                    T.reads(C[b], A[b, i, j])
+                    T.writes(C[b])
+                    if i == 0 and j == 0:
+                        C[b] = T.float32(0)
+                    C[b] = C[b] + A[b, i, j] * A[b, i, j]
+            for i0_1 in T.thread_binding(64, thread="threadIdx.x"):
+                with T.block("D"):
+                    b = T.axis.spatial(1, i0_1)
+                    T.where(i0_1 < 1)
+                    T.reads(C[b])
+                    T.writes(D[b])
+                    D[b] = T.sqrt(C[b], dtype="float32")
+
+
+# pylint: enable=no-member,invalid-name,unused-variable,line-too-long,redefined-outer-name,unexpected-keyword-arg,too-many-nested-blocks
+# fmt: on
+
+
+def test_read_out_of_bound():
+    # This IR should not be mutated in this pass.
+    _check(read_out_of_bound_after_compute_at, read_out_of_bound_after_compute_at)
+
+
+def test_tiled_pooling_cache():
+    # This IR should not be mutated in this pass.
+    _check(tiled_pooling_cache_after_compute_at, tiled_pooling_cache_after_compute_at)
+
+
+def test_batch_norm():
+    _check(batch_norm_after_compute_at, transformed_batch_norm)
+
+
+def test_lower_te():
+    x = te.placeholder((1,))
+    y = te.compute((1,), lambda i: x[i] + 2)
+    s = te.create_schedule(y.op)
+    orig_mod = tvm.driver.build_module.schedule_to_module(s, [x, y])
+    mod = tvm.tir.transform.ApplyBlockBoundPredicate()(orig_mod)
+    tvm.ir.assert_structural_equal(mod, orig_mod)  # FlattenBuffer should do nothing on TE
+
+
+if __name__ == "__main__":
+    test_read_out_of_bound()
+    test_tiled_pooling_cache()
+    test_batch_norm()
+    test_lower_te()


### PR DESCRIPTION
Two main changes are contained in this PR:
* Instead of using loop variables in the bound predicate, we changed to use the block iterators.
* We cannot apply the bound predicate to loops in FlattenBuffer, since the predicate is about block iterators, while after pass ConvertBlocksToOpaque we lost every piece of information about the block iterators. Therefore I added a pass named "ApplyBlockBoundPredicate" before pass ConvertBlocksToOpaque.

Not sure whether the pass name is acceptable. @spectrometerHBH Would you like to help review the PR? I'm not 100% sure whether the PR and the new pass are good. Thanks a lot!