### PR TITLE
[BugFix] Fix CrossThreadReduction on CUDA

### DIFF
--- a/include/tvm/tir/stmt.h
+++ b/include/tvm/tir/stmt.h
@@ -1358,7 +1358,7 @@ constexpr const char* script_parsing_detect_access = "tir.script_parsing_detect_
 constexpr const char* pragma_loop_partition_hint = "pragma_loop_partition_hint";
 
 /*!
- * \brief Mark that the block need to add predicate for block var bounds during lowering 
+ * \brief Mark that the block need to add predicate for block var bounds during lowering
  */
 constexpr const char* require_block_var_bound_predicate = "require_bound_predicate";
 

--- a/include/tvm/tir/transform.h
+++ b/include/tvm/tir/transform.h
@@ -391,6 +391,13 @@ TVM_DLL Pass PlanAndUpdateBufferAllocationLocation();
 TVM_DLL Pass ApplyBlockBoundPredicate();
 
 /*!
+ * \brief Narrow the extents of some loops by checking whether some constraints in the block iter
+ * bound predicates can be directly applied on the loops.
+ * \return The pass.
+ */
+TVM_DLL Pass ApplyBlockBoundPredicate();
+
+/*!
  * \brief Substitute all the block vars with the PrimExprs they are bound to, indicated by the
  *        corresponding iter_values in BlockRealize, for opaque blocks by removing all
  *.        the iter_values in BlockRealize and iter_vars in Block.

--- a/python/tvm/meta_schedule/testing/schedule_rule.py
+++ b/python/tvm/meta_schedule/testing/schedule_rule.py
@@ -42,9 +42,9 @@ def get(target: Target) -> List[ScheduleRule]:
         ]
     if target.kind.name == "cuda":
         return [
-            cross_thread_reduction(target),
             multi_level_tiling(target),
             auto_inline_after_tiling(target),
+            cross_thread_reduction(target),
             parallel_vectorize_unroll(target),
         ]
     raise NotImplementedError(f"{target.kind.name} is not supported")

--- a/python/tvm/meta_schedule/tune.py
+++ b/python/tvm/meta_schedule/tune.py
@@ -150,7 +150,6 @@ class DefaultCUDA:
         )
 
         return [
-            M.CrossThreadReduction(thread_extents=[4, 8, 16, 32, 64, 128, 256, 512]),
             M.MultiLevelTiling(
                 structure="SSSRRSRS",
                 tile_binds=["blockIdx.x", "vthread.x", "threadIdx.x"],
@@ -177,6 +176,7 @@ class DefaultCUDA:
                 require_ordered=False,
                 disallow_op=None,
             ),
+            M.CrossThreadReduction(thread_extents=[4, 8, 16, 32, 64, 128, 256, 512]),
             M.ParallelizeVectorizeUnroll(
                 max_jobs_per_core=-1,  # disable parallelize
                 max_vectorize_extent=-1,  # disable vectorize

--- a/src/meta_schedule/schedule_rule/random_compute_location.cc
+++ b/src/meta_schedule/schedule_rule/random_compute_location.cc
@@ -47,8 +47,8 @@ class RandomComputeLocationNode : public ScheduleRuleNode {
     if (tir::GetChildBlockSRefOnSRefTree(sch->state(), loop_srefs[0]).size() > 1) {
       return false;
     }
-    // Cond 5. The block is not tiled. We check this condition by examine the block's annotation.
-    if (tir::GetAnn<String>(block_sref, tir::attr::meta_schedule_tiling_structure).defined()) {
+    // Cond 5. The block is not tiled.
+    if (tir::HasBeenMultiLevelTiled(block_sref)) {
       return false;
     }
     // Cond 6. The block has at lease one consumer.

--- a/src/tir/schedule/analysis.h
+++ b/src/tir/schedule/analysis.h
@@ -630,6 +630,14 @@ AnalyzeReadWritePattern(const BufferRegion& read_region, const BufferRegion& wri
 bool NeedsMultiLevelTiling(const ScheduleState& self, const StmtSRef& block_sref);
 
 /*!
+ * \brief Checks if the given block has been applied by multi-level tiling. We check this by examine
+ * the block's annotation.
+ * \param block_sref The block to be checked
+ * \return A boolean indicating whether the block has been multi-level tiled.
+ */
+bool HasBeenMultiLevelTiled(const StmtSRef& block_sref);
+
+/*!
  * \brief Checks if the rfactor or cross thread reduction is beneficial to the given block.
  * \param self The schedule state.
  * \param block_sref The block to be checked.


### PR DESCRIPTION
This PR fixes the rule CrossThreadReduction on CUDA with sketch tests of NRM and SFM. Now the performances of NRM and SFM on CUDA are supposed align with Ansor's.

cc @junrushao1994 @spectrometerHBH @Hzfengsy @zxybazh