### PR TITLE
[Meta Schedule] Add customizable search space to PostOrderApply.

### DIFF
--- a/python/tvm/meta_schedule/testing/relay_workload.py
+++ b/python/tvm/meta_schedule/testing/relay_workload.py
@@ -131,6 +131,7 @@ def get_torch_model(
     import os  # type: ignore # pylint: disable=import-error,import-outside-toplevel
 
     def do_trace(model, inp):
+        model.eval()
         model_trace = torch.jit.trace(model, inp)
         model_trace.eval()
         return model_trace
@@ -178,14 +179,12 @@ def get_torch_model(
         }
         configuration = config_dict[model_name]
         model = transformers.BertModel(configuration)
-        input_name = "input_ids"
         A = torch.randint(10000, input_shape)
 
         model.eval()
         scripted_model = torch.jit.trace(model, [A], strict=False)
 
-        input_name = "input_ids"
-        shape_list = [(input_name, input_shape)]
+        shape_list = [("input_ids", input_shape)]
         mod, params = relay.frontend.from_pytorch(scripted_model, shape_list)
         return mod, params
     else:

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -117,12 +117,16 @@ Optional<ObjectRef> ApplyHistoryBestNode::Query(runtime::String task_name, IRMod
   IRModule prim_mod = dispatched.value()[0];
   ICHECK(HasOnlyOneFunction<tir::PrimFunc>(prim_mod)) << prim_mod;
   ICHECK(HasOnlyOneFunction<relay::Function>(mod)) << mod;
+  const auto* parse_mod_func = runtime::Registry::Get("tvm.meta_schedule.tune.parse_mod");
+  prim_mod = (*parse_mod_func)(prim_mod);
   if (database->HasWorkload(prim_mod)) {
+    LOG(INFO) << "Applied history best for " << task_name << "!";
     Array<TuningRecord> records = database->GetTopK(database->CommitWorkload(prim_mod), 1);
     ICHECK(records.size() == 1) << "No records was found for given workload" << prim_mod;
     return records[0]->workload->mod;
-  } else
+  } else {
     return NullOpt;
+  }
 }
 
 /**************** FFI ****************/

--- a/src/meta_schedule/integration.cc
+++ b/src/meta_schedule/integration.cc
@@ -120,13 +120,14 @@ Optional<ObjectRef> ApplyHistoryBestNode::Query(runtime::String task_name, IRMod
   const auto* parse_mod_func = runtime::Registry::Get("tvm.meta_schedule.tune.parse_mod");
   prim_mod = (*parse_mod_func)(prim_mod);
   if (database->HasWorkload(prim_mod)) {
-    LOG(INFO) << "Applied history best for " << task_name << "!";
     Array<TuningRecord> records = database->GetTopK(database->CommitWorkload(prim_mod), 1);
-    ICHECK(records.size() == 1) << "No records was found for given workload" << prim_mod;
-    return records[0]->workload->mod;
-  } else {
-    return NullOpt;
+    // todo(@zxybazh): check if records always exists when the database has the workload
+    if (records.size() == 1) {
+      LOG(INFO) << "Applied history best for " << task_name << "!";
+      return records[0]->workload->mod;
+    }
   }
+  return NullOpt;
 }
 
 /**************** FFI ****************/

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -40,7 +40,16 @@ class BlockCollector : public tir::StmtVisitor {
         blocks_to_collect_.clear();
         VisitStmt(func->body);
         for (const String& block_name : blocks_to_collect_) {
-          results_.push_back(sch_->GetBlock(block_name, func_name_));
+          tir::BlockRV block_rv = sch_->GetBlock(block_name, func_name_);
+          // pick out the blocks with annotation for customized search space
+          if (Optional<ObjectRef> custom_sch_rule_name =
+                  sch_->Get(block_rv)->annotations.Get("rule")) {
+            const auto* custom_sch_rule_func =
+                runtime::Registry::Get(Downcast<String>(custom_sch_rule_name.value()));
+            (*custom_sch_rule_func)(sch_, block_rv);
+          } else {
+            results_.push_back(block_rv);
+          }
         }
       }
     }

--- a/src/meta_schedule/space_generator/post_order_apply.cc
+++ b/src/meta_schedule/space_generator/post_order_apply.cc
@@ -43,7 +43,7 @@ class BlockCollector : public tir::StmtVisitor {
           tir::BlockRV block_rv = sch_->GetBlock(block_name, func_name_);
           // pick out the blocks with annotation for customized search space
           if (Optional<ObjectRef> custom_sch_rule_name_opt =
-                  tir::GetAnn<String>(sch_->GetSRef(block_rv), "rule")) {
+                  tir::GetAnn<String>(sch_->GetSRef(block_rv), "schedule_rule")) {
             String custom_sch_rule_name = Downcast<String>(custom_sch_rule_name_opt.value());
             if (custom_sch_rule_name != "None") {
               const auto* custom_sch_rule_func = runtime::Registry::Get(custom_sch_rule_name);

--- a/src/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/meta_schedule/task_scheduler/task_scheduler.cc
@@ -138,7 +138,7 @@ void TaskSchedulerNode::Tune() {
     } else {
       SetTaskStopped(task_id);
       --running_tasks;
-      LOG(INFO) << "Task #" << task_id << " has finished. Remaining task(s): " << running_tasks;
+      LOG(INFO) << "Task #" << task_id + 1 << " has finished. Remaining task(s): " << running_tasks;
     }
   }
   ICHECK_EQ(running_tasks, 0) << "Not all tasks are finished";

--- a/tests/python/unittest/test_meta_schedule_post_order_apply.py
+++ b/tests/python/unittest/test_meta_schedule_post_order_apply.py
@@ -62,7 +62,7 @@ class MatmulCustomized:
         with T.block("root"):
             for i, j, k in T.grid(1024, 1024, 1024):
                 with T.block("matmul"):
-                    T.block_attr({"rule": "tvm.meta_schedule.test.custom_search_space"})
+                    T.block_attr({"schedule_rule": "tvm.meta_schedule.test.custom_search_space"})
                     vi, vj, vk = T.axis.remap("SSR", [i, j, k])
                     with T.init():
                         C[vi, vj] = 0.0
@@ -78,10 +78,10 @@ class MatmulCustomizedNoneRule:
         B = T.match_buffer(b, (1024, 1024), "float32")
         C = T.match_buffer(c, (1024, 1024), "float32")
         with T.block("root"):
-            T.block_attr({"rule": "None"})
+            T.block_attr({"schedule_rule": "None"})
             for i, j, k in T.grid(1024, 1024, 1024):
                 with T.block("matmul"):
-                    T.block_attr({"rule": "None"})
+                    T.block_attr({"schedule_rule": "None"})
                     vi, vj, vk = T.axis.remap("SSR", [i, j, k])
                     with T.init():
                         C[vi, vj] = 0.0

--- a/tests/python/unittest/test_meta_schedule_post_order_apply.py
+++ b/tests/python/unittest/test_meta_schedule_post_order_apply.py
@@ -59,14 +59,34 @@ class MatmulCustomized:
         A = T.match_buffer(a, (1024, 1024), "float32")
         B = T.match_buffer(b, (1024, 1024), "float32")
         C = T.match_buffer(c, (1024, 1024), "float32")
-        for i, j, k in T.grid(1024, 1024, 1024):
-            with T.block("matmul"):
-                T.block_attr({"rule": "tvm.meta_schedule.test.custom_search_space"})
-                vi, vj, vk = T.axis.remap("SSR", [i, j, k])
-                with T.init():
-                    C[vi, vj] = 0.0
-                C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+        with T.block("root"):
+            for i, j, k in T.grid(1024, 1024, 1024):
+                with T.block("matmul"):
+                    T.block_attr({"rule": "tvm.meta_schedule.test.custom_search_space"})
+                    vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                    with T.init():
+                        C[vi, vj] = 0.0
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
 
+
+@tvm.script.ir_module
+class MatmulCustomizedNoneRule:
+    @T.prim_func
+    def main(a: T.handle, b: T.handle, c: T.handle) -> None:
+        T.func_attr({"global_symbol": "main"})
+        A = T.match_buffer(a, (1024, 1024), "float32")
+        B = T.match_buffer(b, (1024, 1024), "float32")
+        C = T.match_buffer(c, (1024, 1024), "float32")
+        with T.block("root"):
+            T.block_attr({"rule": "None"})
+            for i, j, k in T.grid(1024, 1024, 1024):
+                with T.block("matmul"):
+                    T.block_attr({"rule": "None"})
+                    vi, vj, vk = T.axis.remap("SSR", [i, j, k])
+                    with T.init():
+                        C[vi, vj] = 0.0
+                    C[vi, vj] = C[vi, vj] + A[vi, vk] * B[vk, vj]
+                
 @tvm.script.ir_module
 class DuplicateMatmul:
     @T.prim_func
@@ -356,13 +376,6 @@ def test_meta_schedule_post_order_apply_remove_block():
 
 
 def test_meta_schedule_post_order_apply_custom_search_space():
-    class DontCallThisRule(PyScheduleRule):
-        def initialize_with_tune_context(self, tune_context: "TuneContext") -> None:
-            pass
-
-        def apply(self, sch: Schedule, block: BlockRV) -> List[Schedule]:
-            raise Exception("This rule should not be called!")
-
     @register_func("tvm.meta_schedule.test.custom_search_space")
     def custom_search_space_func(sch: Schedule, block: BlockRV):
         raise ValueError("Customized search space triggered!")
@@ -372,13 +385,33 @@ def test_meta_schedule_post_order_apply_custom_search_space():
         mod=mod,
         target=Target("llvm"),
         task_name="Custom Search Space Task",
-        sch_rules=[DontCallThisRule()],
+        sch_rules=[],
     )
     function_called = False
     post_order_apply = PostOrderApply()
     post_order_apply.initialize_with_tune_context(context)
     with pytest.raises(ValueError, match="Customized search space triggered!"):
         _ = post_order_apply.generate_design_space(mod)
+
+
+def test_meta_schedule_post_order_apply_custom_search_space_none_rule():
+    class DontCallThisRule(PyScheduleRule):
+        def initialize_with_tune_context(self, tune_context: "TuneContext") -> None:
+            pass
+
+        def apply(self, sch: Schedule, block: BlockRV) -> List[Schedule]:
+            raise RuntimeError("This schedule rule should not be called!")
+
+    mod = MatmulCustomizedNoneRule
+    context = TuneContext(
+        mod=mod,
+        target=Target("llvm"),
+        task_name="Custom Search Space Task",
+        sch_rules=[DontCallThisRule()],
+    )
+    post_order_apply = PostOrderApply()
+    post_order_apply.initialize_with_tune_context(context)
+    _ = post_order_apply.generate_design_space(mod)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add the capability to customize a scheduling function for a specific block when doing post order apply of design space generation. Unit test added to verify that the function is invoked.

TBD: What would be the proper args list for the scheduling (block level) function, currently schedule and the block rv.