### PR TITLE
Support rich type annotation

### DIFF
--- a/python/tvm/script/builder/tir/op.py
+++ b/python/tvm/script/builder/tir/op.py
@@ -77,56 +77,56 @@ from tvm.tir.op import (
 from . import _ffi_api
 
 
-def boolean(expr):
-    return _ffi_api.PrimType("bool", expr)
+def int8(expr=None):
+    return _ffi_api.Int8(expr)
 
 
-def int8(expr):
-    return _ffi_api.PrimType("int8", expr)
+def int16(expr=None):
+    return _ffi_api.Int16(expr)
 
 
-def int16(expr):
-    return _ffi_api.PrimType("int16", expr)
+def int32(expr=None):
+    return _ffi_api.Int32(expr)
 
 
-def int32(expr):
-    return _ffi_api.PrimType("int32", expr)
+def int64(expr=None):
+    return _ffi_api.Int64(expr)
 
 
-def int64(expr):
-    return _ffi_api.PrimType("int64", expr)
+def uint8(expr=None):
+    return _ffi_api.UInt8(expr)
 
 
-def uint8(expr):
-    return _ffi_api.PrimType("uint8", expr)
+def uint16(expr=None):
+    return _ffi_api.UInt16(expr)
 
 
-def uint16(expr):
-    return _ffi_api.PrimType("uint16", expr)
+def uint32(expr=None):
+    return _ffi_api.UInt32(expr)
 
 
-def uint32(expr):
-    return _ffi_api.PrimType("uint32", expr)
+def uint64(expr=None):
+    return _ffi_api.UInt64(expr)
 
 
-def uint64(expr):
-    return _ffi_api.PrimType("uint64", expr)
+def float8(expr=None):
+    return _ffi_api.Float8(expr)
 
 
-def float8(expr):
-    return _ffi_api.PrimType("float8", expr)
+def float16(expr=None):
+    return _ffi_api.Float16(expr)
 
 
-def float16(expr):
-    return _ffi_api.PrimType("float16", expr)
+def float32(expr=None):
+    return _ffi_api.Float32(expr)
 
 
-def float32(expr):
-    return _ffi_api.PrimType("float32", expr)
+def float64(expr=None):
+    return _ffi_api.Float64(expr)
 
 
-def float64(expr):
-    return _ffi_api.PrimType("float64", expr)
+def boolean(expr=None):
+    return _ffi_api.Boolean(expr)
 
 
 def handle():

--- a/python/tvm/script/builder/tir/var.py
+++ b/python/tvm/script/builder/tir/var.py
@@ -20,12 +20,20 @@ from tvm import tir
 from . import _ffi_api
 
 
-def Buffer(  # pylint: disable=invalid-name
-    shape,
-    dtype="float32",
-    name="buffer",
-    storage_scope="",
-) -> tir.Buffer:
-    return _ffi_api.Buffer(
-        shape, dtype, name, storage_scope
-    )  # pylint: disable=no-member # type: ignore
+class BufferProxy:
+    def __call__(
+        self,
+        shape,
+        dtype="float32",
+        *,
+        storage_scope="",
+    ) -> tir.Buffer:
+        return _ffi_api.Buffer(  # pylint: disable=no-member # type: ignore
+            shape, dtype, "", storage_scope
+        )
+
+    def __getitem__(self, keys) -> tir.Buffer:
+        return self(*keys)  # pylint: disable=no-member # type: ignore
+
+
+Buffer = BufferProxy()

--- a/python/tvm/script/parse/doc_core.py
+++ b/python/tvm/script/parse/doc_core.py
@@ -83,39 +83,6 @@ class FunctionDef(stmt):
         self.returns = returns
 
 
-class AsyncFunctionDef(stmt):
-    _FIELDS = [
-        "name",
-        "args",
-        "body",
-        "decorator_list",
-        "returns",
-        "lineno",
-        "col_offset",
-        "end_lineno",
-        "end_col_offset",
-    ]
-
-    def __init__(
-        self,
-        name,
-        args,
-        body,
-        decorator_list,
-        returns,
-        lineno,
-        col_offset,
-        end_lineno,
-        end_col_offset,
-    ):
-        super().__init__(lineno, col_offset, end_lineno, end_col_offset)
-        self.name = name
-        self.args = args
-        self.body = body
-        self.decorator_list = decorator_list
-        self.returns = returns
-
-
 class ClassDef(stmt):
     _FIELDS = [
         "name",
@@ -249,26 +216,6 @@ class For(stmt):
         self.orelse = orelse
 
 
-class AsyncFor(stmt):
-    _FIELDS = [
-        "target",
-        "iter",
-        "body",
-        "orelse",
-        "lineno",
-        "col_offset",
-        "end_lineno",
-        "end_col_offset",
-    ]
-
-    def __init__(self, target, iter, body, orelse, lineno, col_offset, end_lineno, end_col_offset):
-        super().__init__(lineno, col_offset, end_lineno, end_col_offset)
-        self.target = target
-        self.iter = iter
-        self.body = body
-        self.orelse = orelse
-
-
 class While(stmt):
     _FIELDS = [
         "test",
@@ -306,15 +253,6 @@ class If(stmt):
 
 
 class With(stmt):
-    _FIELDS = ["items", "body", "lineno", "col_offset", "end_lineno", "end_col_offset"]
-
-    def __init__(self, items, body, lineno, col_offset, end_lineno, end_col_offset):
-        super().__init__(lineno, col_offset, end_lineno, end_col_offset)
-        self.items = items
-        self.body = body
-
-
-class AsyncWith(stmt):
     _FIELDS = ["items", "body", "lineno", "col_offset", "end_lineno", "end_col_offset"]
 
     def __init__(self, items, body, lineno, col_offset, end_lineno, end_col_offset):
@@ -593,14 +531,6 @@ class GeneratorExp(expr):
         super().__init__(lineno, col_offset, end_lineno, end_col_offset)
         self.elt = elt
         self.generators = generators
-
-
-class Await(expr):
-    _FIELDS = ["value", "lineno", "col_offset", "end_lineno", "end_col_offset"]
-
-    def __init__(self, value, lineno, col_offset, end_lineno, end_col_offset):
-        super().__init__(lineno, col_offset, end_lineno, end_col_offset)
-        self.value = value
 
 
 class Yield(expr):

--- a/python/tvm/script/parse/tir/tir.py
+++ b/python/tvm/script/parse/tir/tir.py
@@ -87,8 +87,17 @@ def visit_arguments(self: Parser, node: doc.arguments) -> None:
     # - kwarg: arg | None
     # - defaults: list[expr]
     # - posonlyargs: list[arg]
+    arg: doc.arg
     for arg in node.args:
         if arg.annotation is None:
             self.report_error(arg, "Type annotation is required for function parameters.")
-        param = T.arg(arg.arg, self.eval_expr(arg.annotation))
+        param = T.arg(arg.arg, self.visit_tvm_annotation(arg.annotation))
         self.var_table.add(arg.arg, param)
+
+
+@dispatch.register(token="tir", type_name="tvm_annotation")
+def visit_tvm_annotation(self: Parser, node: doc.expr):
+    annotation = self.eval_expr(node)
+    if callable(annotation):
+        annotation = annotation()
+    return annotation

--- a/src/script/builder/tir/op.cc
+++ b/src/script/builder/tir/op.cc
@@ -23,14 +23,25 @@ namespace script {
 namespace builder {
 namespace tir {
 
+TVM_REGISTER_GLOBAL("script.builder.tir.Int8").set_body_typed(Int8);
+TVM_REGISTER_GLOBAL("script.builder.tir.Int16").set_body_typed(Int16);
+TVM_REGISTER_GLOBAL("script.builder.tir.Int32").set_body_typed(Int32);
+TVM_REGISTER_GLOBAL("script.builder.tir.Int64").set_body_typed(Int64);
+TVM_REGISTER_GLOBAL("script.builder.tir.UInt8").set_body_typed(UInt8);
+TVM_REGISTER_GLOBAL("script.builder.tir.UInt16").set_body_typed(UInt16);
+TVM_REGISTER_GLOBAL("script.builder.tir.UInt32").set_body_typed(UInt32);
+TVM_REGISTER_GLOBAL("script.builder.tir.UInt64").set_body_typed(UInt64);
+TVM_REGISTER_GLOBAL("script.builder.tir.Float8").set_body_typed(Float8);
+TVM_REGISTER_GLOBAL("script.builder.tir.Float16").set_body_typed(Float16);
+TVM_REGISTER_GLOBAL("script.builder.tir.Float32").set_body_typed(Float32);
+TVM_REGISTER_GLOBAL("script.builder.tir.Float64").set_body_typed(Float64);
+TVM_REGISTER_GLOBAL("script.builder.tir.Boolean").set_body_typed(Boolean);
 TVM_REGISTER_GLOBAL("script.builder.tir.PrimType").set_body_typed(PrimType);
 TVM_REGISTER_GLOBAL("script.builder.tir.Handle").set_body_typed(Handle);
-TVM_REGISTER_GLOBAL("script.builder.tir.min").set_body_typed([](PrimExpr a, PrimExpr b) {
-  return tvm::min(a, b);
-});
-TVM_REGISTER_GLOBAL("script.builder.tir.max").set_body_typed([](PrimExpr a, PrimExpr b) {
-  return tvm::max(a, b);
-});
+TVM_REGISTER_GLOBAL("script.builder.tir.min")
+    .set_body_typed([](PrimExpr a, PrimExpr b) -> PrimExpr { return tvm::min(a, b); });
+TVM_REGISTER_GLOBAL("script.builder.tir.max")
+    .set_body_typed([](PrimExpr a, PrimExpr b) -> PrimExpr { return tvm::max(a, b); });
 
 }  // namespace tir
 }  // namespace builder

--- a/src/script/builder/tir/op.h
+++ b/src/script/builder/tir/op.h
@@ -29,20 +29,73 @@ namespace script {
 namespace builder {
 namespace tir {
 
-inline PrimExpr Int8(PrimExpr expr) { return tvm::cast(DataType::Int(8), expr); }
-inline PrimExpr Int16(PrimExpr expr) { return tvm::cast(DataType::Int(16), expr); }
-inline PrimExpr Int32(PrimExpr expr) { return tvm::cast(DataType::Int(32), expr); }
-inline PrimExpr Int64(PrimExpr expr) { return tvm::cast(DataType::Int(64), expr); }
-inline PrimExpr Uint8(PrimExpr expr) { return tvm::cast(DataType::UInt(8), expr); }
-inline PrimExpr Uint16(PrimExpr expr) { return tvm::cast(DataType::UInt(16), expr); }
-inline PrimExpr Uint32(PrimExpr expr) { return tvm::cast(DataType::UInt(32), expr); }
-inline PrimExpr Uint64(PrimExpr expr) { return tvm::cast(DataType::UInt(64), expr); }
-inline PrimExpr Float8(PrimExpr expr) { return tvm::cast(DataType::Float(8), expr); }
-inline PrimExpr Float16(PrimExpr expr) { return tvm::cast(DataType::Float(16), expr); }
-inline PrimExpr Float32(PrimExpr expr) { return tvm::cast(DataType::Float(32), expr); }
-inline PrimExpr Float64(PrimExpr expr) { return tvm::cast(DataType::Float(64), expr); }
-inline PrimExpr Bool(PrimExpr expr) { return tvm::cast(DataType::Bool(), expr); }
+inline PrimExpr Int8(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::Int(8);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr Int16(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::Int(16);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr Int32(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::Int(32);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr Int64(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::Int(64);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr UInt8(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::UInt(8);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr UInt16(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::UInt(16);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr UInt32(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::UInt(32);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr UInt64(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::UInt(64);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr Float8(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::Float(8);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr Float16(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::Float(16);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr Float32(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::Float(32);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr Float64(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::Float(64);
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
+inline PrimExpr Boolean(Optional<PrimExpr> expr = NullOpt) {
+  DataType dtype = DataType::Bool();
+  return expr.defined() ? tvm::cast(dtype, expr.value()) : tvm::tir::Var("", dtype);
+}
+
 inline tvm::tir::Var Handle() { return tvm::tir::Var("", DataType::Handle()); }
+
 inline PrimExpr PrimType(DataType dtype, PrimExpr expr) { return tvm::cast(dtype, expr); }
 
 using tvm::cast;

--- a/src/script/builder/tir/prim_func_frame.cc
+++ b/src/script/builder/tir/prim_func_frame.cc
@@ -201,7 +201,7 @@ TVM_REGISTER_GLOBAL("script.builder.tir.Arg")
       if (const auto* buffer = obj.as<BufferNode>()) {
         return Arg(name, GetRef<tvm::tir::Buffer>(buffer));
       }
-      LOG(FATAL) << "ValueError: Unexpected type for TIR Arg.";
+      LOG(FATAL) << "ValueError: Unexpected type for TIR Arg: " << obj->GetTypeKey();
       throw;
     });
 TVM_REGISTER_GLOBAL("script.builder.tir.FuncName").set_body_typed(FuncName);

--- a/tests/python/tvmscript/test_parse_basic.py
+++ b/tests/python/tvmscript/test_parse_basic.py
@@ -8,7 +8,7 @@ def test_parse_elementwise():
     # pylint: disable=unused-argument,unused-variable,invalid-name
     @T.prim_func
     def elementwise(
-        A: T.Buffer(shape=(128, 128, 128), dtype="float32"),  # type: ignore
+        A: T.Buffer[(128, 128), "float32"],
         B: T.Buffer(shape=(128, 128, 128), dtype="float32"),  # type: ignore
     ) -> None:
         for i, j, *vvv, k in T.grid(128, 128, 128, 128, 128, 128, 128):
@@ -21,7 +21,7 @@ def test_parse_elementwise():
     # pylint: enable=unused-argument,unused-variable,invalid-name
 
     result = elementwise
-    # print(result.script())
+    print(result.script())
 
 
 def test_parse_skip():
@@ -51,10 +51,24 @@ def test_parse_class():
 
     # pylint: enable=unused-argument,unused-variable,invalid-name
 
-    # print(C.script())
+    print(C.script())
+
+
+def test_parse_atomic():
+    @T.prim_func
+    def f(A: T.int32, B: T.int64, C: T.handle) -> None:
+        pass
+
+    assert f.params[0].name == "A"
+    assert f.params[0].dtype == "int32"
+    assert f.params[1].name == "B"
+    assert f.params[1].dtype == "int64"
+    assert f.params[2].name == "C"
+    assert f.params[2].dtype == "handle"
 
 
 if __name__ == "__main__":
     test_parse_elementwise()
     test_parse_skip()
     test_parse_class()
+    test_parse_atomic()


### PR DESCRIPTION
This PR supports:

```python
def f(
  A: T.int32,
  B: T.int64,
  C: T.handle,
  D: T.Buffer[(128, 128), "float32"],
) -> None:
  ...
```